### PR TITLE
Fix typo in mul2 comment

### DIFF
--- a/mul2.gs
+++ b/mul2.gs
@@ -9,7 +9,7 @@ function mul2( args )
     return
   endif
 
-*** arguement ***
+*** argument ***
   imax = subwrd( args, 1 )
   jmax = subwrd( args, 2 )
   ipos = subwrd( args, 3 )


### PR DESCRIPTION
## Summary
- correct spelling in mul2 comment

## Testing
- `grads -blc "run mul2.gs 1 1 1 1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a57b969cfc832d8f0b627daadc9e10